### PR TITLE
change dependency from Perl::Critic::Utils to PPIx::Utils

### DIFF
--- a/lib/Perl/MinimumVersion.pm
+++ b/lib/Perl/MinimumVersion.pm
@@ -51,9 +51,9 @@ use List::Util          1.20    qw(max first);
 use Params::Util        0.25    ('_INSTANCE', '_CLASS');
 use PPI::Util                   ('_Document');
 use PPI                 1.215   ();
-use Perl::Critic::Utils 1.104   qw{
+use PPIx::Utils                 qw{
 	:classification
-	:ppi
+	:traversal
 };
 use PPIx::Regexp        0.033;
 use Perl::MinimumVersion::Reason ();


### PR DESCRIPTION
Depending on Perl::Critic brings a huge dependency chain to this widely used module. PPIx::Utils is a fork of these functions that mostly just depends on PPI. Ref: https://github.com/adamkennedy/Perl-MinimumVersion/issues/2 and https://github.com/adamkennedy/PPI/issues/78