### PR TITLE
Added README, .editorconfig; updated issues links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root=true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+
+[.git/*]
+indent_style = space	# for commit messages

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# perlver - The Perl Minimum Version Analyzer
+
+## SYNOPSIS
+
+    adam@red:~$ perlver Perl-MinimumVersion
+    Found directory '.'
+    Searching for Perl files... found 3 file(s)
+    Scanning lib/Perl/MinimumVersion.pm... done
+    Scanning t/01_compile.t... done
+    Scanning t/02_main.t... done
+
+        ---------------------------------------------------------
+      | file                       | explicit | syntax | external |
+      | --------------------------------------------------------- |
+      | lib/Perl/MinimumVersion.pm | 5.005    | ~      | n/a      |
+      | t/01_compile.t             | ~        | ~      | n/a      |
+      | t/02_main.t                | ~        | ~      | n/a      |
+        ---------------------------------------------------------
+
+    Minimum version of Perl required: ...
+
+    adam@red:~$
+
+## DESCRIPTION
+
+`perlver` is a console script created to provide convenient access to the
+functionality provided by [Perl::MinimumVersion](https://metacpan.org/pod/Perl::MinimumVersion).
+
+\--blame option shows code which requires this version of perl
+
+The synopsis above pretty much covers all you need to know at this point.
+
+# AUTHORS
+
+- Adam Kennedy <adamk@cpan.org>
+- Neil Bowers <neil@bowers.com>
+
+# SEE ALSO
+
+[PPI](https://metacpan.org/pod/PPI), [Perl::MinimumVersion](https://metacpan.org/pod/Perl::MinimumVersion)
+
+# COPYRIGHT
+
+Copyright 2005 - 2012 Adam Kennedy.
+Copyright 2015 - 2019 Neil Bowers and contributors.
+
+This program is free software; you can redistribute
+it and/or modify it under the same terms as Perl itself.
+
+The full text of the license can be found in the
+LICENSE file included with this module.

--- a/lib/Perl/MinimumVersion.pm
+++ b/lib/Perl/MinimumVersion.pm
@@ -650,7 +650,7 @@ sub _experimental_bundle {
     my ($version, $obj);
 
     shift->Document->find( sub {
-        return '' unless $_[1]->isa('PPI::Statement::Include') 
+        return '' unless $_[1]->isa('PPI::Statement::Include')
                      and $_[1]->pragma eq 'experimental';
 
         my @child = $_[1]->schildren;
@@ -1452,8 +1452,8 @@ explicit version dependencies.
 
 B<However> it is exceedingly easy to add a new syntax check, so if you
 find something this is missing, copy and paste one of the existing
-5 line checking functions, modify it to find what you want, and report it
-to rt.cpan.org, along with the version needed.
+5 line checking functions, modify it to find what you want, and report it,
+along with the version needed.
 
 I don't even need an entire diff... just the function and version.
 
@@ -1476,15 +1476,27 @@ C<package NAME VERSION;>, C<...>, and C<use feature ':5.12'>)>
 
 =head1 SUPPORT
 
-All bugs should be filed via the CPAN bug tracker at
+Bugs can be filed via the CPAN or GitHub bug trackers:
+
+=over
+
+=item *
 
 L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Perl-MinimumVersion>
+
+=item *
+
+L<https://github.com/neilb/Perl-MinimumVersion/issues>
+
+=back
 
 For other issues, or commercial enhancement or support, contact the author.
 
 =head1 AUTHORS
 
 Adam Kennedy E<lt>adamk@cpan.orgE<gt>
+
+Neil Bowers E<lt>neil@bowers.comE<gt>
 
 =head1 SEE ALSO
 
@@ -1503,6 +1515,7 @@ L<https://github.com/neilbowers/Perl-MinimumVersion>
 =head1 COPYRIGHT
 
 Copyright 2005 - 2014 Adam Kennedy.
+Copyright 2015 - 2019 Neil Bowers and contributors.
 
 This program is free software; you can redistribute
 it and/or modify it under the same terms as Perl itself.

--- a/script/perlver
+++ b/script/perlver
@@ -403,9 +403,19 @@ sub dist ($) {
 
 =head1 SUPPORT
 
-All bugs should be filed via the bug tracker at
+Bugs can be filed via the CPAN or GitHub bug trackers:
+
+=over
+
+=item *
 
 L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Perl-MinimumVersion>
+
+=item *
+
+L<https://github.com/neilb/Perl-MinimumVersion/issues>
+
+=back
 
 For other issues, or commercial enhancement and support, contact the author
 
@@ -420,6 +430,7 @@ L<PPI>, L<Perl::MinimumVersion>
 =head1 COPYRIGHT
 
 Copyright 2005 - 2012 Adam Kennedy.
+Copyright 2015 - 2019 Neil Bowers and contributors.
 
 This program is free software; you can redistribute
 it and/or modify it under the same terms as Perl itself.


### PR DESCRIPTION
- Added a README.md converted from script/perlver, for the sake of
  the GitHub repo.
- Added the GitHub issues link alongside the the CPAN issues link
- Added a .editorconfig file to help with consistency in formatting.
  As far as I can tell from the source, it's Unix linefeeds, tab
  indents, and four-space tabs.  I got the four-space tabs from
  [lib/Perl/MinimumVersion.pm:459--460](https://github.com/cxw42/Perl-MinimumVersion/blob/341cf795aba51fad79b4126fd9903f774024522b/lib/Perl/MinimumVersion.pm#L459), which don't indent correctly
  with two-space tabs.  Of course, I could be wrong!