### PR TITLE
Add support for detecting heredoc-indent syntax (<<~)

### DIFF
--- a/lib/Perl/MinimumVersion.pm
+++ b/lib/Perl/MinimumVersion.pm
@@ -66,6 +66,8 @@ BEGIN {
 
 	# The primary list of version checks
 	%CHECKS = (
+		_heredoc_indent         => version->new('5.025.007'),
+
         # _stacked_labels         => version->new('5.014'),
 
 		_yada_yada_yada         => version->new('5.012'),
@@ -932,6 +934,14 @@ sub _get_resulting_sigil {
 	}
 }
 
+sub _heredoc_indent {
+	shift->Document->find_first( sub {
+		my $main_element = $_[1];
+		$main_element->isa('PPI::Token::HereDoc') or return '';
+		$main_element->content =~ /^\Q<<~\E/ or return '';
+		return 1;
+	});
+}
 
 sub _postfix_when {
 	shift->Document->find_first( sub {

--- a/t/29_heredoc_indent.t
+++ b/t/29_heredoc_indent.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Perl::MinimumVersion;
+
+my %examples=(
+    q{
+    my $var = <<~HEREDOC;
+    My text.
+    HEREDOC
+    } => '5.025007',
+
+    q{
+    my $var = <<HEREDOC;
+My text.
+HEREDOC
+    } => '5.004',
+);
+
+plan tests => scalar keys %examples;
+
+foreach my $example (sort keys %examples) {
+    my $v = Perl::MinimumVersion->new(\$example)->minimum_version;
+    is( $v, $examples{$example}, $example )
+        or $@ && diag $@;
+}


### PR DESCRIPTION
Cross-ref with [<<~](https://metacpan.org/pod/Syntax::Construct#%3C%3C%7E).

Fixes <https://github.com/neilb/Perl-MinimumVersion/issues/26>.
