### PR TITLE
Check for "use re /flags" (using PPIx::Regexp)

### DIFF
--- a/lib/Perl/MinimumVersion.pm
+++ b/lib/Perl/MinimumVersion.pm
@@ -55,7 +55,7 @@ use PPIx::Utils                 qw{
 	:classification
 	:traversal
 };
-use PPIx::Regexp        0.033;
+use PPIx::Regexp        0.051;
 use Perl::MinimumVersion::Reason ();
 
 our (@ISA, @EXPORT_OK, %CHECKS, @CHECKS_RV ,%MATCHES);
@@ -97,8 +97,8 @@ BEGIN {
 		_pragma_utf8            => version->new('5.008'),
 	);
 	@CHECKS_RV = ( #subs that return version
-	    '_feature_bundle','_regex','_each_argument','_binmode_2_arg',
-        '_scheduled_blocks', '_experimental_bundle'
+		'_feature_bundle', '_regex', '_re_flags', '_each_argument', '_binmode_2_arg',
+		'_scheduled_blocks', '_experimental_bundle',
 	);
 
 	# Predefine some indexes needed by various check methods
@@ -694,6 +694,31 @@ sub _regex {
 				$obj = $_[1];
 			}
 		return '';
+	} );
+	$version = undef if ($version and $version eq '5.000');
+	return ($version, $obj);
+}
+
+# Check for use re "/flags";
+sub _re_flags {
+	my ($version, $obj);
+	shift->Document->find( sub {
+		return '' unless $_[1]->isa('PPI::Statement::Include')
+			and ($_[1]->module eq 're' or $_[1]->pragma eq 're');
+		my $included = $_[1]->schild(2);
+		my @literal = $included->can('literal') ? $included->literal() : $included->string();
+		my $v = "5.005";
+		my @flags = grep {index($_, '/') == 0} @literal;
+		$v = '5.014' if @flags;
+		$v = max $v, map {
+			my $empty_regex_w_flag = "/$_";
+			PPIx::Regexp->new( $empty_regex_w_flag )->perl_version_introduced;
+		} @flags;
+		if ($v and $v > ($version || 0) ) {
+			$version = $v;
+			$obj = $_[1];
+		}
+
 	} );
 	$version = undef if ($version and $version eq '5.000');
 	return ($version, $obj);

--- a/t/30_re_flags.t
+++ b/t/30_re_flags.t
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More 0.47;
+
+use Perl::MinimumVersion;
+
+my %examples=(
+    q{use re "/xx"; }         => '5.025009',
+    q{use re "/mxsx"; }       => '5.025009',
+    q{use re "debug"; }       => '5.006',
+    q{use re; }               => '5.006',
+    q{use re qw(taint /xx); } => '5.025009',
+    q{use re qw(taint /x); }  => '5.014',
+    q{use re "/x"}            => '5.014',
+    q{use re qw</n>; }        => '5.021008',
+    q{use re qw</n /xx>; }    => '5.025009',
+);
+
+plan tests => scalar keys %examples;
+
+foreach my $example (sort keys %examples) {
+    my $v = Perl::MinimumVersion->new(\$example)->minimum_version;
+    is( $v, $examples{$example}, $example )
+        or $@ && diag $@;
+}


### PR DESCRIPTION
Alternative approach for <https://github.com/neilb/Perl-MinimumVersion/pull/24>.

---

/flags was added in 5.014, and /xx was added in 5.026.

Fixes #19.
