### PR TITLE
Add support for double diamond (<<>>), Perl 5.21.5.

### DIFF
--- a/lib/Perl/MinimumVersion.pm
+++ b/lib/Perl/MinimumVersion.pm
@@ -50,7 +50,7 @@ use Exporter                    ();
 use List::Util          1.20    qw(max first);
 use Params::Util        0.25    ('_INSTANCE', '_CLASS');
 use PPI::Util                   ('_Document');
-use PPI                 1.215   ();
+use PPI                 1.252   ();
 use PPIx::Utils                 qw{
 	:classification
 	:traversal
@@ -70,6 +70,7 @@ BEGIN {
 
         # _stacked_labels         => version->new('5.014'),
 
+		_double_diamond_operator => version->new('5.021.005'),
 		_yada_yada_yada         => version->new('5.012'),
 		_pkg_name_version       => version->new('5.012'),
 		_postfix_when           => version->new('5.012'),
@@ -1098,6 +1099,16 @@ sub _use_carp_version {
 
 		my $version = $_[1]->module_version;
 		return !! ( defined $version and length "$version" );
+	} );
+}
+
+# Double-diamond operator.
+# Detecting this requires at least PPI 1.252
+sub _double_diamond_operator {
+	shift->Document->find_first( sub {
+		$_[1]->isa('PPI::Token::QuoteLike::Readline') or return '';
+		$_[1]->content eq '<<>>'		or return '';
+		return 1;
 	} );
 }
 

--- a/t/02_main.t
+++ b/t/02_main.t
@@ -11,7 +11,7 @@ BEGIN {
 use Test::More 0.47 tests => 90;
 use version 0.76;
 use File::Spec::Functions ':ALL';
-use PPI 1.215;
+use PPI 1.252;
 use Perl::MinimumVersion 'PMV';
 
 sub version_is {

--- a/t/30_double_diamond_operator.t
+++ b/t/30_double_diamond_operator.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+
+use strict;
+BEGIN {
+	$|  = 1;
+	$^W = 1;
+}
+
+use Test::More 0.47;
+
+#use version;
+use Perl::MinimumVersion;
+my @examples_not=(
+    qw{ < > <> },
+);
+my @examples_yes=(
+    qw{ <<>> },
+);
+plan tests =>(@examples_not+@examples_yes);
+foreach my $example (@examples_not) {
+	my $p = Perl::MinimumVersion->new(\$example);
+	is( $p->_double_diamond_operator, '', $example )
+	  or do { diag "\$\@: $@" if $@ };
+}
+foreach my $example (@examples_yes) {
+	my $p = Perl::MinimumVersion->new(\$example);
+	ok( $p->_double_diamond_operator, $example )
+	  or do { diag "\$\@: $@" if $@ };
+}
+


### PR DESCRIPTION
This requires PPI 1.252 to detect.